### PR TITLE
Add Jest and unit tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src'],
+  moduleNameMapper: {
+    '^app/(.*)$': '<rootDir>/src/app/$1'
+  }
+};

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "make 5000 project",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "jest",
     "start": "NODE_OPTIONS=--openssl-legacy-provider DISABLE_TYPESCRIPT=true webpack-dev-server --mode development --hot --progress --color --port 3000 --open --host 0.0.0.0",
     "build": "webpack -p --progress --colors",
     "lint": "tslint --project tsconfig.json 'src/**/*.ts'"
@@ -46,7 +46,9 @@
     "webpack": "^4.12.0",
     "webpack-cleanup-plugin": "^0.5.1",
     "webpack-cli": "^3.0.3",
-    "webpack-dev-server": "^3.1.4"
+    "webpack-dev-server": "^3.1.4",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1"
   },
   "dependencies": {
     "@types/lodash": "^4.14.116",

--- a/src/app/utils/__tests__/index.test.ts
+++ b/src/app/utils/__tests__/index.test.ts
@@ -1,0 +1,18 @@
+import { tryMerge } from 'app/utils';
+
+describe('tryMerge', () => {
+  it('returns the next coin value when merge reaches it', () => {
+    expect(tryMerge(1, 10)).toBe(10);
+    expect(tryMerge(50, 3)).toBe(100);
+    expect(tryMerge(100, 5)).toBe(500);
+  });
+
+  it('returns the original value when insufficient to upgrade', () => {
+    expect(tryMerge(50, 1)).toBe(50);
+    expect(tryMerge(100, 2)).toBe(100);
+  });
+
+  it('caps at the highest defined coin value', () => {
+    expect(tryMerge(1000, 5)).toBe(1000);
+  });
+});


### PR DESCRIPTION
## Summary
- set up Jest with ts-jest
- add unit tests for `tryMerge`
- update npm test script

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684592682e5c833385cf05f33c4c3852