### PR TITLE
Remove Prettier mention from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ $ npm start
 $ npm run build
 ```
 
-## Prettier
+## Lint
 
 ```
-$ npm run prettier
+$ npm run lint
 ```
 
 # License


### PR DESCRIPTION
## Summary
- document lint npm script
- remove outdated Prettier instructions

## Testing
- `npm run lint` *(fails: tslint not found)*

------
https://chatgpt.com/codex/tasks/task_e_68459262aa288333a63f9c5bf7f70256