### PR TITLE
Fix recursive call in getSameAdjacentCoinsWithValue

### DIFF
--- a/src/app/utils/index.ts
+++ b/src/app/utils/index.ts
@@ -125,25 +125,25 @@ export function getSameAdjacentCoinsWithValue(
   // up
   if (row > 0 && coins[row - 1][col] === value) {
     const pos = { col, row: row - 1 };
-    result = result.concat(getSameAdjacentCoins(pos, coins));
+    result = result.concat(getSameAdjacentCoinsWithValue(pos, value, coins));
   }
 
   // down
   if (row < CONST.GAME_SIZE - 1 && coins[row + 1][col] === value) {
     const pos = { col, row: row + 1 };
-    result = result.concat(getSameAdjacentCoins(pos, coins));
+    result = result.concat(getSameAdjacentCoinsWithValue(pos, value, coins));
   }
 
   // left
   if (col > 0 && coins[row][col - 1] === value) {
     const pos = { row, col: col - 1 };
-    result = result.concat(getSameAdjacentCoins(pos, coins));
+    result = result.concat(getSameAdjacentCoinsWithValue(pos, value, coins));
   }
 
   // right
   if (col < CONST.GAME_SIZE - 1 && coins[row][col + 1] === value) {
     const pos = { row, col: col + 1 };
-    result = result.concat(getSameAdjacentCoins(pos, coins));
+    result = result.concat(getSameAdjacentCoinsWithValue(pos, value, coins));
   }
 
   return result;


### PR DESCRIPTION
## Summary
- ensure getSameAdjacentCoinsWithValue recursively calls itself

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint` *(fails: tslint not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845925e75808333aa4b60c6232f1b24