### PR TITLE
Fix README: drop missing prettier instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,6 @@ $ npm start
 ```
 $ npm run build
 ```
-
-## Prettier
-
-```
-$ npm run prettier
-```
-
 # License
 
 MIT


### PR DESCRIPTION
## Summary
- remove instructions to run a nonexistent `prettier` script

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68459a70b86c8333867ca5878d77adbf