### PR TITLE
Fix build by locking Node 18

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ## Setup
 
+This project expects **Node.js 18** during build. Other versions may cause errors.
+
 ```
 $ npm install
 ```

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "make500",
   "version": "0.0.1",
   "private": true,
+  "engines": {
+    "node": "18.x"
+  },
   "description": "make 5000 project",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- add an engines field to specify Node.js 18
- document the Node 18 requirement

## Testing
- `npm run lint` *(fails: `tslint: not found`)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68459bf8621483339cfde5f70760c6d1