### PR TITLE
Fix react-image peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "react-clipboard.js": "^2.0.0",
         "react-dom": "^17.0.0",
         "react-ga": "^2.5.3",
-        "react-image": "^1.4.1",
+        "react-image": "^4.1.0",
         "react-redux": "^7.2.9",
         "react-router": "^5.3.4",
         "redux": "^4.0.0",
@@ -9653,17 +9653,18 @@
       }
     },
     "node_modules/react-image": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/react-image/-/react-image-1.5.1.tgz",
-      "integrity": "sha512-UHVXGmv9NttI5nWlvXdqxqzbfRebZSmHTT4n5hsUb0uElYXwE71+Zla4/KZjjU96Z6eZPT66OFSVwd2wwBOKyg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/react-image/-/react-image-4.1.0.tgz",
+      "integrity": "sha512-ox1HcO3hjJ0mtOjFxeZ7cq2cqZ3RHC1uDssn08hjp2uJg/hD/fCY1oGfZvzBKCV9MVx/c4IcVnkWUuagS8y0mQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.0.0",
         "prop-types": "15.6.2"
       },
       "peerDependencies": {
-        "react": "^15 || ^16",
-        "react-dom": "^15 || ^16"
+        "@babel/runtime": ">=7",
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "react-clipboard.js": "^2.0.0",
     "react-dom": "^17.0.0",
     "react-ga": "^2.5.3",
-    "react-image": "^1.4.1",
+    "react-image": "^4.1.0",
     "react-redux": "^7.2.9",
     "react-router": "^5.3.4",
     "redux": "^4.0.0",

--- a/src/app/components/GameCoinBox.tsx
+++ b/src/app/components/GameCoinBox.tsx
@@ -4,7 +4,7 @@ import { Directions } from 'app/models';
 import { CONST } from 'app/utils';
 import { IMAGES } from 'app/constants/images';
 
-const Img = require('react-image').default;
+import Img from 'react-image';
 
 export namespace GameCoinBox {
   export interface Props {


### PR DESCRIPTION
## Summary
- update `react-image` to version 4.1.0
- adjust import for new version

## Testing
- `npx tsc --noEmit` *(fails: JSX expressions must have one parent element)*

------
https://chatgpt.com/codex/tasks/task_e_6845a481da188333a95a24fb4c1697e8