### PR TITLE
Fix static asset server path

### DIFF
--- a/server.js
+++ b/server.js
@@ -3,15 +3,15 @@ const path = require('path');
 const port = process.env.PORT || 8080;
 const app = express();
 
-app.use(express.static(__dirname + '/dist'))
-
-app.get('/assets/**/:file', function(request, response) {
-  response.sendFile(path.resolve(__dirname, 'src/' + request.path));
-});
+// Serve built files
+app.use(express.static(path.join(__dirname, 'dist')));
+// Serve static assets such as images and fonts
+app.use('/assets', express.static(path.join(__dirname, 'src/assets')));
 
 app.get('*', function(request, response) {
   response.sendFile(path.resolve(__dirname, 'dist', 'index.html'));
-})
+});
 
-app.listen(port, '0.0.0.0')
-console.log("server started on port " + port);
+app.listen(port, '0.0.0.0');
+console.log('server started on port ' + port);
+


### PR DESCRIPTION
## Summary
- fix static asset routing in `server.js`

## Testing
- `npm run lint` *(fails: tslint not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845ac621e008333be89f71343429295