### PR TITLE
Fix express asset route

### DIFF
--- a/server.js
+++ b/server.js
@@ -3,15 +3,12 @@ const path = require('path');
 const port = process.env.PORT || 8080;
 const app = express();
 
-app.use(express.static(__dirname + '/dist'))
-
-app.get('/assets/**/:file', function(request, response) {
-  response.sendFile(path.resolve(__dirname, 'src/' + request.path));
-});
+app.use(express.static(path.join(__dirname, 'dist')));
+app.use('/assets', express.static(path.join(__dirname, 'src/assets')));
 
 app.get('*', function(request, response) {
   response.sendFile(path.resolve(__dirname, 'dist', 'index.html'));
-})
+});
 
-app.listen(port, '0.0.0.0')
-console.log("server started on port " + port);
+app.listen(port, '0.0.0.0');
+console.log('server started on port ' + port);


### PR DESCRIPTION
## Summary
- update asset route to use express.static

## Testing
- `npx tslint --project tsconfig.json 'src/**/*.ts'` *(fails: Need to install tslint)*

------
https://chatgpt.com/codex/tasks/task_e_6845adb7ed9c83338fa761ca0556df9e