### PR TITLE
Use imported images instead of raw paths

### DIFF
--- a/src/app/components/Game.tsx
+++ b/src/app/components/Game.tsx
@@ -1,22 +1,5 @@
 import * as React from 'react';
-// 이미지 경로 수정
-import gameBoxHold from '../../assets/images/game_box_hold.png';
-import gameBoxNext from '../../assets/images/game_box_next.png';
-import mouseBtnRetry from '../../assets/images/pause_btn_retry.png';
-import gameCoin from '../../assets/images/game_coin_1.png';
-
-// JSX에서 사용
-<img src={gameBoxHold} alt="Box Hold" />
-
-// 방법 2: require 사용
-<img src={require('../../assets/images/game_box_hold.png')} alt="Box Hold" />
-
-// GitHub Raw URL 사용
-const gameBoxHold = 'https://raw.githubusercontent.com/username/repo/main/images/game_box_hold.png';
-const gameBoxNext = 'https://raw.githubusercontent.com/username/repo/main/images/game_box_next.png';
-
-// JSX에서 사용
-<img src={gameBoxHold} alt="Box Hold" />
+import { IMAGES } from 'app/constants/images';
 
 export interface GameProps {
   // 필요한 props 정의
@@ -59,7 +42,7 @@ export class Game extends React.Component<GameProps, GameState> {
         <div className="game-board">
           {/* 상단 영역 (다음 블록 표시) */}
           <div className="next-block-area">
-            <img src={gameBoxNext} alt="Next Block" />
+            <img src={IMAGES.GAME_BOX_NEXT} alt="Next Block" />
             {/* 다음 블록 내용 */}
           </div>
           
@@ -71,13 +54,13 @@ export class Game extends React.Component<GameProps, GameState> {
           
           {/* 현재 블록 영역 */}
           <div className="current-block">
-            <img src={gameBoxHold} alt="Current Block" />
+            <img src={IMAGES.GAME_BOX_HOLD} alt="Current Block" />
             {/* 현재 블록 내용 */}
           </div>
           
           {/* 재시작 버튼 */}
           <div className="retry-button">
-            <img src={mouseBtnRetry} alt="Retry" onClick={this.handleRetry} />
+            <img src={IMAGES.MOUSE_BTN_RETRY} alt="Retry" onClick={this.handleRetry} />
           </div>
         </div>
       </div>

--- a/src/app/components/GameOverUI.tsx
+++ b/src/app/components/GameOverUI.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 const Clipboard = require('react-clipboard.js').default;
 
 import { CONST, S3_HOST } from 'app/utils';
+import { IMAGES } from 'app/constants/images';
 
 export namespace GameOverUI {
   export interface Props {
@@ -49,7 +50,7 @@ export class GameOverUI extends React.Component<GameOverUI.Props, GameOverUI.Sta
             {
               this.isNewRecord() && <img
                 style={styles.newRecord}
-                src={require('../../assets/images/game_result_new.png')}
+                src={IMAGES.GAME_RESULT_NEW}
               />
             }
           </div>
@@ -69,7 +70,7 @@ export class GameOverUI extends React.Component<GameOverUI.Props, GameOverUI.Sta
           >
               <img
                 style={styles.image}
-                src={require('../../assets/images/main_btn_twitter.png')}
+                src={IMAGES.MAIN_BTN_TWITTER}
               />
           </Clipboard>
         </div>
@@ -85,7 +86,7 @@ export class GameOverUI extends React.Component<GameOverUI.Props, GameOverUI.Sta
           >
             <img
               style={styles.image}
-              src={require('../../assets/images/pause_btn_retry.png')}
+              src={IMAGES.MOUSE_BTN_RETRY}
             />
           </div>
         </div>

--- a/src/app/constants/images.ts
+++ b/src/app/constants/images.ts
@@ -1,27 +1,44 @@
-// 이미지 경로를 중앙에서 관리
-const IMAGES_PATH = '/assets/images';
+// 개별 이미지 파일을 불러와 중앙에서 관리
+import gameBoxHold from '../assets/images/game_box_hold.png';
+import gameBoxNext from '../assets/images/game_box_next.png';
+import mouseBtnRetry from '../assets/images/pause_btn_retry.png';
+import gameCoin1 from '../assets/images/game_coin_1.png';
+import gameCoin5 from '../assets/images/game_coin_5.png';
+import gameCoin10 from '../assets/images/game_coin_10.png';
+import gameCoin50 from '../assets/images/game_coin_50.png';
+import gameCoin100 from '../assets/images/game_coin_100.png';
+import gameCoin500 from '../assets/images/game_coin_500.png';
+import gameCoin1000 from '../assets/images/game_coin_1000.png';
+import gameCoinboxDown from '../assets/images/game_coinbox_down.png';
+import gameCoinboxLeft from '../assets/images/game_coinbox_left.png';
+import gameCoinboxRight from '../assets/images/game_coinbox_right.png';
+import gameCoinboxUp from '../assets/images/game_coinbox_up.png';
+import gameResultNew from '../assets/images/game_result_new.png';
+import gameBtnPlay from '../assets/images/game_btn_play.png';
+import gameBtnPause from '../assets/images/game_btn_pause.png';
+import mainBtnTwitter from '../assets/images/main_btn_twitter.png';
 
 export const IMAGES = {
-  GAME_BOX_HOLD: `${IMAGES_PATH}/game_box_hold.png`,
-  GAME_BOX_NEXT: `${IMAGES_PATH}/game_box_next.png`,
-  MOUSE_BTN_RETRY: `${IMAGES_PATH}/pause_btn_retry.png`,
-  GAME_COIN_1: `${IMAGES_PATH}/game_coin_1.png`,
-  GAME_COIN_5: `${IMAGES_PATH}/game_coin_5.png`,
-  GAME_COIN_10: `${IMAGES_PATH}/game_coin_10.png`,
-  GAME_COIN_50: `${IMAGES_PATH}/game_coin_50.png`,
-  GAME_COIN_100: `${IMAGES_PATH}/game_coin_100.png`,
-  GAME_COIN_500: `${IMAGES_PATH}/game_coin_500.png`,
-  GAME_COIN_1000: `${IMAGES_PATH}/game_coin_1000.png`,
-  GAME_COINBOX_DOWN: `${IMAGES_PATH}/game_coinbox_down.png`,
-  GAME_COINBOX_LEFT: `${IMAGES_PATH}/game_coinbox_left.png`,
-  GAME_COINBOX_RIGHT: `${IMAGES_PATH}/game_coinbox_right.png`,
-  GAME_COINBOX_UP: `${IMAGES_PATH}/game_coinbox_up.png`,
-  GAME_RESULT_NEW: `${IMAGES_PATH}/game_result_new.png`,
-  GAME_BTN_PLAY: `${IMAGES_PATH}/game_btn_play.png`,
-  GAME_BTN_PAUSE: `${IMAGES_PATH}/game_btn_pause.png`,
-  MAIN_BTN_TWITTER: `${IMAGES_PATH}/main_btn_twitter.png`,
+  GAME_BOX_HOLD: gameBoxHold,
+  GAME_BOX_NEXT: gameBoxNext,
+  MOUSE_BTN_RETRY: mouseBtnRetry,
+  GAME_COIN_1: gameCoin1,
+  GAME_COIN_5: gameCoin5,
+  GAME_COIN_10: gameCoin10,
+  GAME_COIN_50: gameCoin50,
+  GAME_COIN_100: gameCoin100,
+  GAME_COIN_500: gameCoin500,
+  GAME_COIN_1000: gameCoin1000,
+  GAME_COINBOX_DOWN: gameCoinboxDown,
+  GAME_COINBOX_LEFT: gameCoinboxLeft,
+  GAME_COINBOX_RIGHT: gameCoinboxRight,
+  GAME_COINBOX_UP: gameCoinboxUp,
+  GAME_RESULT_NEW: gameResultNew,
+  GAME_BTN_PLAY: gameBtnPlay,
+  GAME_BTN_PAUSE: gameBtnPause,
+  MAIN_BTN_TWITTER: mainBtnTwitter,
   // 기타 이미지들...
-}; 
+};
 
 // 코인 이미지를 숫자 값으로 쉽게 접근할 수 있는 헬퍼 함수
 export function getCoinImage(value: number): string {

--- a/src/app/containers/Replay/index.tsx
+++ b/src/app/containers/Replay/index.tsx
@@ -18,6 +18,7 @@ import {
   mergePoint,
   S3_HOST,
 } from 'app/utils';
+import { IMAGES } from 'app/constants/images';
 
 export namespace App {
   interface RouteParam {
@@ -91,8 +92,8 @@ export class App extends React.Component<App.Props, App.State> {
           coins={this.props.game.candidates}
           savedCoin={this.props.game.savedCoin}
           image={this.state.autoPlay ?
-            require('../../../assets/images/game_btn_pause.png') :
-            require('../../../assets/images/game_btn_play.png')}
+            IMAGES.GAME_BTN_PAUSE :
+            IMAGES.GAME_BTN_PLAY}
           onSaveClick={() => {}}
           onImageClick={() => { this.toggleAutoPlay(); }}
         />


### PR DESCRIPTION
## Summary
- manage image assets with imports in `IMAGES`
- switch components to use `IMAGES` constants

## Testing
- `npm run build` *(fails: webpack not found)*
- `npm run lint` *(fails: tslint not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845b177ba0883339b8098523c11bb5c